### PR TITLE
UTF8 File encoding for SBT built

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,7 +38,7 @@ if ! test -e project/build.properties; then
         exit 1
 fi
 
-    
+
 if grep -q -v 'sbt.version *= *0\.11\.[0-9]' project/build.properties; then
 	echo " !      Error, you have defined an unsupported sbt.version in project/build.properties"
 	echo " !      You must use a release verison of sbt, sbt.version=0.11.0 or greater"
@@ -58,7 +58,7 @@ SBT_JAR="sbt-launch-$SBT_VERSION.jar"
 SBT_PROPS="sbt-$SBT_VERSION.boot.properties"
 SBT_URL="http://s3.amazonaws.com/heroku-jvm-langpack-scala/$SBT_JAR"
 SBT_PROPS_URL="http://s3.amazonaws.com/heroku-jvm-langpack-scala/$SBT_PROPS"
-#0.10.1 SBT_SHA1="b41d79cb2d919a0e8732fb8ef4e71347cceea90a" 
+#0.10.1 SBT_SHA1="b41d79cb2d919a0e8732fb8ef4e71347cceea90a"
 #0.11.0-RC1 SBT_SHA1="85abf74a24593c2b2ea5b033ef01c47b11c04740"
 SBT_SHA1="5b15ba0fc63e355d47293def4bc2e58da6f03787"
 ## in 0.10 start-script will depend on package, if packaging
@@ -118,7 +118,7 @@ mkdir -p "$SBT_USER_HOME/.sbt/plugins" && curl --silent --max-time 10 --location
 # build app
 echo "-----> Running: sbt $SBT_TASKS"
 test -e "$SBT_BINDIR"/sbt.boot.properties && PROPS_OPTION="-Dsbt.boot.properties=$SBT_BINDIR/sbt.boot.properties"
-HOME="$SBT_USER_HOME_ABSOLUTE" java -Xmx512M -Duser.home="$SBT_USER_HOME_ABSOLUTE" -Dsbt.log.noformat=true -Divy.default.ivy.user.dir="$SBT_USER_HOME_ABSOLUTE/.ivy2" $PROPS_OPTION -jar "$SBT_BINDIR"/$SBT_JAR $SBT_TASKS 2>&1 | sed -u 's/^/       /'
+HOME="$SBT_USER_HOME_ABSOLUTE" java -Xmx512M -Dfile.encoding=UTF8 -Duser.home="$SBT_USER_HOME_ABSOLUTE" -Dsbt.log.noformat=true -Divy.default.ivy.user.dir="$SBT_USER_HOME_ABSOLUTE/.ivy2" $PROPS_OPTION -jar "$SBT_BINDIR"/$SBT_JAR $SBT_TASKS 2>&1 | sed -u 's/^/       /'
 if [ "${PIPESTATUS[*]}" != "0 0" ]; then
   echo " !     Failed to build app with sbt"
   exit 1


### PR DESCRIPTION
At SBT build time, set the file encoding to UTF8 so we handle source files with non-ascii characters in them
