### PR TITLE
Fixed sbt version checking issue

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -38,19 +38,17 @@ if ! test -e project/build.properties; then
         exit 1
 fi
 
-
-if grep -q -v 'sbt.version *= *0\.11\.[0-9]' project/build.properties; then
-	echo " !      Error, you have defined an unsupported sbt.version in project/build.properties"
-	echo " !      You must use a release verison of sbt, sbt.version=0.11.0 or greater"
-	exit 1
-fi
-
 if grep -q 'sbt.version *= *0\.11\.[0-9]-RC' project/build.properties; then
 	echo " !      Error, you have defined an unsupported sbt.version in project/build.properties"
 	echo " !      You must use a release verison of sbt, sbt.version=0.11.0 or greater"
 	exit 1
 fi
 
+if ! grep -q 'sbt.version *= *0\.11\.[0-9]$' project/build.properties; then
+	echo " !      Error, you have defined an unsupported sbt.version in project/build.properties"
+	echo " !      You must use a release verison of sbt, sbt.version=0.11.0 or greater"
+	exit 1
+fi
 
 
 SBT_VERSION="0.11.0"


### PR DESCRIPTION
Hi,

I have just fixed an issue with sbt version checking. The issue was that if project/build.properties contained anything - even empty line after sbt.version=0.11.2, validation failed. It was caused by wrong grep command - 'grep -v <the right version pattern>' was used. It of course, matched anything extra in the file (even empty line) and caused an error, which explained nothing 'unsupported sbt version'.

I have performed tests for 4 cases - no file, RC version, wrong version, right version, right version with newline.
