### PR TITLE
More Permanent Generation space for compile.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -128,7 +128,7 @@ cp $OPT_DIR/$HEROKU_PLUGIN $SBT_USER_HOME/.sbt/plugins/$HEROKU_PLUGIN
 # build app
 echo "-----> Running: sbt $SBT_TASKS"
 test -e "$SBT_BINDIR"/sbt.boot.properties && PROPS_OPTION="-Dsbt.boot.properties=$SBT_BINDIR/sbt.boot.properties"
-HOME="$SBT_USER_HOME_ABSOLUTE" java -Xmx1024M -Dfile.encoding=UTF8 -Duser.home="$SBT_USER_HOME_ABSOLUTE" -Dsbt.log.noformat=true -Divy.default.ivy.user.dir="$SBT_USER_HOME_ABSOLUTE/.ivy2" $PROPS_OPTION -jar "$SBT_BINDIR"/$SBT_JAR $SBT_TASKS 2>&1 | sed -u 's/^/       /'
+HOME="$SBT_USER_HOME_ABSOLUTE" java -Xmx1024M -XX:PermSize=256m -Dfile.encoding=UTF8 -Duser.home="$SBT_USER_HOME_ABSOLUTE" -Dsbt.log.noformat=true -Divy.default.ivy.user.dir="$SBT_USER_HOME_ABSOLUTE/.ivy2" $PROPS_OPTION -jar "$SBT_BINDIR"/$SBT_JAR $SBT_TASKS 2>&1 | sed -u 's/^/       /'
 if [ "${PIPESTATUS[*]}" != "0 0" ]; then
   echo " !     Failed to build app with sbt"
   exit 1


### PR DESCRIPTION
When I tried to push a Play 2.0 application to Heroku, I got an "java.lang.OutOfMemoryError: PermGen space".

The full error message is:

```
   [info] Compiling 20 Scala sources and 34 Java sources to /tmp/build_3ra28o3q8fp8s/target/scala-2.9.1/classes...
   [success] Total time: 40 s, completed Oct 22, 2012 1:05:52 PM
   sbt appears to be exiting abnormally.
     The log file for this session is at /tmp/sbt4671502314349822780.log
   java.lang.OutOfMemoryError: PermGen space
   Error during sbt execution: java.lang.OutOfMemoryError: PermGen space
```

 !     Failed to build app with sbt
 !     Heroku push rejected, failed to compile Play 2.0 - java app

This pull request simply add more PermGen memory.
