### PR TITLE
Support for Play 2.1-RC2

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -46,9 +46,8 @@ get_supported_sbt_version() {
   local ctxDir=$1
   if _has_buildPropertiesFile $ctxDir; then
     sbtVersionLine="$(grep -P '[ \t]*sbt\.version[ \t]*=' "${ctxDir}"/project/build.properties | sed -E -e 's/[ \t\r\n]//g')"
-    sbtVersion=$(expr "$sbtVersionLine" : 'sbt\.version=\(0\.1[1-2]\.[0-9]\)$')
-    if [ "$sbtVersion" != 0 ] ; then
-      echo "$sbtVersion"
+    if [[ "$sbtVersionLine" =~ sbt\.version=(0\.1[1-2]\.[0-9](-RC[0-9])?)$  ]] ; then	
+       echo "${BASH_REMATCH[1]}"
     else
       echo ""
     fi


### PR DESCRIPTION
The lastest [Play version](https://groups.google.com/d/topic/play-framework/m6w0deY9LMM/discussion) uses sbt 0.12.2-RC2.

This commit adds support to any sbt release candidate.

But there is still a problem because http://s3.amazonaws.com/heroku-jvm-langpack-scala/sbt-0.12.2-RC2.boot.properties is not found by [the compile script](https://github.com/heroku/heroku-buildpack-scala/blob/master/bin/compile#L121).
