### PR TITLE
No doc gen

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -110,7 +110,7 @@ else
 fi
 
 # copy in heroku sbt plugin
-HEROKU_PLUGIN="Heroku-0.11.3.scala"
+HEROKU_PLUGIN="HerokuPlugin.scala"
 mkdir -p "$SBT_USER_HOME/.sbt/plugins"
 cp $OPT_DIR/$HEROKU_PLUGIN $SBT_USER_HOME/.sbt/plugins/$HEROKU_PLUGIN
 

--- a/opt/HerokuPlugin.scala
+++ b/opt/HerokuPlugin.scala
@@ -1,7 +1,7 @@
 import sbt._
 import Keys._
 
-object Heroku extends Plugin {
+object HerokuPlugin extends Plugin {
   override def settings = Seq(
     externalResolvers <<= resolvers map { appResolvers =>
       Seq(Resolver.defaultLocal) ++ appResolvers ++


### PR DESCRIPTION
This still goes through the `doc` task, but provides no sources to compile, so is effectively skipped resulting in faster builds.

Fixes #42 
