### PR TITLE
sbt should use java on PATH

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,7 +102,7 @@ if [ ! -f "$SBT_BINDIR"/"$SBT_JAR" ]; then
   echo "done"
 
   echo "#!/usr/bin/env bash" > sbt
-  echo "/usr/bin/java -Dsbt.boot.properties=/app/.sbt_home/bin/sbt.boot.properties  -Duser.home=/app/.sbt_home -Divy.default.ivy.user.dir=/app/.sbt_home/.ivy2 -jar /app/.sbt_home/bin/$SBT_JAR \"\$@\"" >> sbt
+  echo "java -Dsbt.boot.properties=/app/.sbt_home/bin/sbt.boot.properties  -Duser.home=/app/.sbt_home -Divy.default.ivy.user.dir=/app/.sbt_home/.ivy2 -jar /app/.sbt_home/bin/$SBT_JAR \"\$@\"" >> sbt
   chmod a+x sbt
 
   cd $BUILD_DIR


### PR DESCRIPTION
The [`sbt` script](https://github.com/heroku/heroku-buildpack-scala/blob/447a0e99aedbd21853f49832cb995d182a159a1e/bin/compile#L104-L106) generated by the buildpack for use in run processes should use `java` on the `PATH` instead of `/usr/bin/java`; otherwise, the Java version set in `system.properties` is not respected.
