### PR TITLE
Post build slug ignore file processing implemented

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -132,6 +132,19 @@ for DIR in $CACHED_DIRS; do
   cache_copy $DIR $BUILD_DIR $CACHE_DIR
 done
 
+# To enable post build explicit file dropping from slug, configure the environment to drop files after building app:
+# $ heroku config:set POST_BUILD_SLUG_IGNORE=true
+if [ "$POST_BUILD_SLUG_IGNORE" = "true" ] ; then
+  if [ -f .slugignore ]; then
+	while read f; do
+		for i in `find . -name "$f"`; do
+	    	echo "-----> Dropping file $i from the slug"
+			rm -rf $i
+		done
+	done < "${BUILD_DIR}"/.slugignore
+  fi
+fi
+
 # drop useless directories from slug for play only
 if is_play $BUILD_DIR ; then
   if [ -d $SBT_USER_HOME/.ivy2 ]; then


### PR DESCRIPTION
Finally our team has came across the slug size "problem". It was a matter of time. We've realized that the .slugignore file is the "way to go" but as the documentation states "the .slugignore file causes files to be removed after you push code to Heroku and before the buildpack runs".

We've implemented a variation of the bin/compile file in order to activate post build .slugignore file processing, allowing file dropping (ex. jars from dependencies or any file matching the patterns in .slugignore) resulting in a smaller slug size. 

It is needed to set the config variable POST_BUILD_SLUG_IGNORE to true and to create a .slugignore file on the root directory of your app, containing the file patterns you want to drop from slug.