### PR TITLE
added support for release candidate versions of sbt

### DIFF
--- a/bin/common
+++ b/bin/common
@@ -46,7 +46,7 @@ get_supported_sbt_version() {
   local ctxDir=$1
   if _has_buildPropertiesFile $ctxDir; then
     sbtVersionLine="$(grep -P '[ \t]*sbt\.version[ \t]*=' "${ctxDir}"/project/build.properties | sed -E -e 's/[ \t\r\n]//g')"
-    sbtVersion=$(expr "$sbtVersionLine" : 'sbt\.version=\(0\.1[1-3]\.[0-9]\(-RC[1-9]\)*\)$')
+    sbtVersion=$(expr "$sbtVersionLine" : 'sbt\.version=\(0\.1[1-3]\.[0-9]\(-[a-zA-Z0-9_]*\)*\)$')
     if [ "$sbtVersion" != 0 ] ; then
       echo "$sbtVersion"
     else

--- a/test/common_test.sh
+++ b/test/common_test.sh
@@ -152,7 +152,20 @@ EOF
   assertCapturedEquals "${EXPECTED_VERSION}-RC3"
 }
 
-testGetSbtVersionWithTrailingLetters()
+testGetSbtVersionWithBeta()
+{
+  mkdir -p ${BUILD_DIR}/project
+  cat > ${BUILD_DIR}/project/build.properties <<EOF
+sbt.version   =    ${EXPECTED_VERSION}-Beta1
+EOF
+
+  capture get_supported_sbt_version ${BUILD_DIR}
+
+  assertCapturedSuccess
+  assertCapturedEquals "${EXPECTED_VERSION}-Beta1"
+}
+
+testGetSbtVersionWithMServer()
 {
   mkdir -p ${BUILD_DIR}/project
   cat > ${BUILD_DIR}/project/build.properties <<EOF
@@ -162,7 +175,20 @@ EOF
   capture get_supported_sbt_version ${BUILD_DIR}
 
   assertCapturedSuccess
-  assertCapturedEquals ""
+  assertCapturedEquals "${EXPECTED_VERSION}-MSERVER-1"
+}
+
+testGetSbtVersionDateNumbers()
+{
+  mkdir -p ${BUILD_DIR}/project
+  cat > ${BUILD_DIR}/project/build.properties <<EOF
+sbt.version   =    ${EXPECTED_VERSION}-20140730-062239
+EOF
+
+  capture get_supported_sbt_version ${BUILD_DIR}
+
+  assertCapturedSuccess
+  assertCapturedEquals "${EXPECTED_VERSION}-20140730-062239"
 }
 
 testGetSbtVersionWithNoSpaces() {

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -166,13 +166,6 @@ testCompile_WithNonDefaultVersion()
   assertCaptured "Specified SBT version should actually be used" "Getting org.scala-tools.sbt sbt_2.9.1 ${specifiedSbtVersion}" 
 }
 
-testCompile_WithRCVersion() {
-  local specifiedSbtVersion="${DEFAULT_SBT_VERSION}-RC"
-  createSbtProject ${specifiedSbtVersion}
-  compile
-  assertCaptured "A release candidate version should not be supported." "Error, you have defined an unsupported sbt.version in project/build.properties" 
-}
-
 testCompile_WithMultilineBuildProperties() {
   createSbtProject
   mkdir -p ${BUILD_DIR}/project
@@ -231,12 +224,20 @@ testComplile_BuildPropertiesFileWithUnsupportedOldVersion()
   assertCapturedError "You must use a release verison of sbt, sbt.version=${DEFAULT_SBT_VERSION} or greater"
 }
 
-testComplile_BuildPropertiesFileWithUnsupportedRCVersion()
+testComplile_BuildPropertiesFileWithRCVersion()
 {
-  createSbtProject "0.11.0-RC"
+  createSbtProject "0.13.5-RC1"
 
   compile
   
-  assertCapturedError "Error, you have defined an unsupported sbt.version in project/build.properties"
-  assertCapturedError "You must use a release verison of sbt, sbt.version=${DEFAULT_SBT_VERSION} or greater"
+  assertCaptured "Multiline properties file should detect sbt version" "Downloading SBT"
+}
+
+testComplile_BuildPropertiesFileWithMServerVersion()
+{
+  createSbtProject "0.13.6-MSERVER-1"
+
+  compile
+  
+  assertCaptured "Multiline properties file should detect sbt version" "Downloading SBT"
 }


### PR DESCRIPTION
The PR enables support for Release Candidate versions of SBT. Such as this in the build.properties file:

```
sbt.version=0.13.5-RC1
```

This change has been tested with the following applications (as well as a few others):
https://github.com/naaman/spray-bootstrap
https://github.com/jkutner/sample-play-app
