### PR TITLE
sbt console

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -102,24 +102,8 @@ if [ ! -f "$SBT_BINDIR"/"$SBT_JAR" ]; then
   cd $BUILD_DIR
 fi
 
-rm -f $SBT_BINDIR/sbt
-cat << EOF > $SBT_BINDIR/sbt
-#!/usr/bin/env bash
-
-if [ "\$@" == "console" ]
-  scalaLibraryJar=\$(ls . | grep "org.scala-lang.scala-library")
-  scalaVersion=\$(expr \${scalaLibraryJar} : "\(2\.[0-9]\+\.[0-9]\+\(\-[a-zA-Z0-9]\+\)\?\)")
-  scalaCompilerJar="scala-compiler-\${scalaVersion}.jar"
-  scalaCompilerUrl="http://central.maven.org/maven2/org/scala-lang/scala-compiler/\${scalaVersion}/\${scalaCompilerJar}"
-
-  curl --silent --max-time 60 -o target/universal/stage/lib/\$scalaCompilerJar \$scalaCompilerUrl --fail || error "Failed to download \${scalaCompilerJar}"
-
-  java -cp target/universal/stage/lib/* scala.tools.nsc.MainGenericRunner -usejavacp
-else
-  echo "[error] Not a valid command: \$@"
-fi
-java  -Duser.home=/app/.sbt_home -Divy.default.ivy.user.dir=/app/.sbt_home/.ivy2 -jar /app/.sbt_home/bin/$SBT_JAR "\$@"
-EOF
+# Install the custom sbt script for cmds like `heroku run sbt console`
+cp -p $OPT_DIR/sbt-launcher.sh $SBT_BINDIR/sbt
 chmod a+x $SBT_BINDIR/sbt
 
 # copy in heroku sbt plugin

--- a/opt/sbt-launcher.sh
+++ b/opt/sbt-launcher.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+if [ "$@" == "console" ]; then
+  scalaLibraryJar=$(ls /app/target/universal/stage/lib | grep "org.scala-lang.scala-library")
+  scalaVersion=$(expr ${scalaLibraryJar} : ".*-\(2\.[0-9]\+\.[0-9]\+\(\-[a-zA-Z0-9]\+\)\?\)\.jar")
+
+  if [ -n "$scalaVersion" ]; then
+    scalaHome="/tmp/scala-complete"
+    mkdir -p ${scalaHome}
+    scalaUrl="http://www.scala-lang.org/files/archive/scala-${scalaVersion}.tgz"
+
+    echo -n "Installing Scala ${scalaVersion} compiler..."
+    curl --silent --max-time 60 $scalaUrl | tar zxm -C $scalaHome
+    echo " done"
+
+    java -cp /app/target/universal/stage/lib/*:${scalaHome}/scala-${scalaVersion}/lib/* scala.tools.nsc.MainGenericRunner -usejavacp
+    exit 0
+  fi
+fi
+
+java -Duser.home=/app/.sbt_home -Divy.default.ivy.user.dir=/app/.sbt_home/.ivy2 -jar /app/.sbt_home/bin/sbt-launch.jar "$@"


### PR DESCRIPTION
`heroku run sbt console` was broken for newer apps (anything that had it's first deploy after e983d05093f8745c2d07986a44f5c06bd32a585e)

I also removed sbt.boot.properties from its options, and moved the `sbt` creation outside of the `if` block to force it to happen for existing apps. 
