### PR TITLE
drop sbt boot dir from slug because it's already in the cache

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -141,6 +141,10 @@ if is_sbt_native_packager $BUILD_DIR || is_play $BUILD_DIR; then
     echo "-----> Dropping ivy cache from the slug"
     rm -rf $SBT_USER_HOME/.ivy2
   fi
+  if [ -d $SBT_USER_HOME/boot ] ; then
+    echo "-----> Dropping sbt boot dir from the slug"
+    rm -rf $SBT_USER_HOME/boot
+  fi
   if [ -d $BUILD_DIR/project/boot ] ; then
     echo "-----> Dropping project boot dir from the slug"
     rm -rf $BUILD_DIR/project/boot


### PR DESCRIPTION
to fix #95 
