### PR TITLE
Java 7 for ElasticSearch.

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,7 @@ mkdir -p $CACHE_DIR
 
 # create default system.properties
 if [ ! -f ${BUILD_DIR}/system.properties ]; then
-  echo "java.runtime.version=1.6" > ${BUILD_DIR}/system.properties
+  echo "java.runtime.version=1.7" > ${BUILD_DIR}/system.properties
 fi
 
 # install JDK


### PR DESCRIPTION
The ElasticSearch Java client library requires Java 7. Users will not be able to deploy their Play apps if they are using ElasticSearch.
