### PR TITLE
Adding the clean task

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -71,7 +71,7 @@ SBT_URL="http://typesafe.artifactoryonline.com/typesafe/ivy-releases/org.scala-s
 ## in 0.10 start-script will depend on package, if packaging
 ## is required - it may not be, we can run .class files or a package-war
 ## instead.
-SBT_TASKS="compile stage"
+SBT_TASKS="clean compile stage"
 
 # To enable clean compiles, configure the environment to clean:
 # $ heroku config:set SBT_CLEAN=true


### PR DESCRIPTION
I don't know why the `clean` task has been removed from the sbt tasks (currently `sbt compile stage`).

I added this because I was unable to compile my project, because some deleted files where still present in folders.
Works like a charm after cleaning the projects.