### PR TITLE
Clean up coursier cache directory after sbt build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -169,6 +169,10 @@ if is_sbt_native_packager $BUILD_DIR || is_play $BUILD_DIR; then
       status "Dropping ivy cache from the slug"
       rm -rf $SBT_USER_HOME/.ivy2
     fi
+    if [ "$KEEP_COURSIER_CACHE" != "true" ] && [ -d $SBT_USER_HOME/.coursier ]; then
+      status "Dropping coursier cache from the slug"
+      rm -rf $SBT_USER_HOME/.coursier
+    fi
     if [ -d $SBT_USER_HOME/boot ] ; then
       status "Dropping sbt boot dir from the slug"
       rm -rf $SBT_USER_HOME/boot


### PR DESCRIPTION
More and more sbt projects are using the coursier plugin to manage do…wnloding dependencies. Coursier saves its cache in a different directory to Ivy, but the post-compile cleanup script does not currently remove this, leading to the cached dependencies bloating the slug.

This change adds code to the `compile` script to remove the coursier cache after completing the sbt tasks, with the same checks as are done for the ivy cache.