### PR TITLE
Fix testRemovePlayForkRun test [changelog skip]

### DIFF
--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -175,7 +175,7 @@ testCleanCompile()
 
 testRemovePlayForkRun()
 {
-  createPlayProject
+  createPlayProject "2.3.10" "0.13.17" "2.10.7"
   mkdir -p ${BUILD_DIR}/project
   touch ${BUILD_DIR}/project/play-fork-run.sbt
 


### PR DESCRIPTION
This test broke out of a sudden. It tested with a very old version of Play and some dependencies could no longer be resolved. I bumped the minor version and added explicit sbt and Scala versions as well. This fixes the test for now. Overall, tests in this repo need a refresher.