### PR TITLE
Download JVM Common from buildpack-registry instead of codon-buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* Download the JVM Common buildpack from the buildpack registry, rather than the legacy `codon-buildpacks` S3 bucket.
 * Remove heroku-16 support
 
 ## v90

--- a/bin/compile
+++ b/bin/compile
@@ -50,7 +50,7 @@ export_env $ENV_DIR "." "JAVA_OPTS"
 # Set system properties as env vars
 SYSPROPFILE="$BUILD_DIR/system.properties"
 
-JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-"https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/jvm-common.tgz"}
+JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-"https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz"}
 JVM_COMMON_BUILDPACK=$(get_property "$SYSPROPFILE" "heroku.jvm.buildpack" "$JVM_COMMON_BUILDPACK")
 KEEP_PLAY_FORK_RUN=$(get_property "$SYSPROPFILE" "sbt.keep-play-fork-run" "${KEEP_PLAY_FORK_RUN:-false}")
 SBT_PROJECT=$(get_property "$SYSPROPFILE" "sbt.project")


### PR DESCRIPTION
The `codon-buildpacks` S3 bucket has been deprecated for many years, having been replaced by the buildpack registry shorthand aliases, which map to the `buildpack-registry` S3 bucket instead.

New buildpack releases are currently backported to the legacy `codon-buildpacks` bucket from `buildpack-registry` by a sync job (so this PR has no change on functionality), however that job will be sunset soon, causing `codon-buildpacks` to become stale.

GUS-W-10034067.