### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
             sudo apt-get install file
       - run:
           name: Download and unpack shunit 2.1.6
-          command: curl -sSf https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+          command: curl -sSf --fail --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
       - run:
           name: Clone heroku-buildpack-testrunner
           command: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* Adjust curl retry and connection timeout handling
 * Vendor buildpack-stdlib rather than downloading it at build time
 * Switch to the recommended regional S3 domain instead of the global one
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -171,7 +171,7 @@ _download_and_unpack_ivy_cache() {
     ivyCacheUrl="$baseUrl-base.tar.gz"
   fi
 
-  curl --retry 3 --silent --max-time 60 --location $ivyCacheUrl | tar xzm -C $sbtUserHome
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --max-time 60 --location $ivyCacheUrl | tar xzm -C $sbtUserHome
   if [ $? -eq 0 ]; then
     mv $sbtUserHome/.sbt/* $sbtUserHome
     rm -rf $sbtUserHome/.sbt
@@ -324,7 +324,7 @@ install_jdk() {
   let start=$(nowms)
   JVM_COMMON_BUILDPACK=${JVM_COMMON_BUILDPACK:-https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz}
   mkdir -p /tmp/jvm-common
-  curl --retry 3 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --location $JVM_COMMON_BUILDPACK | tar xzm -C /tmp/jvm-common --strip-components=1
   source /tmp/jvm-common/bin/util
   source /tmp/jvm-common/bin/java
   source /tmp/jvm-common/opt/jdbc.sh


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.