### PR TITLE
Only provision Heroku Postgres addon if required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Main
 
+* Only provision Heroku Postgres if the app declares a dependency to one of the following postgres drivers:
+    - [Official Postgres JDBC Driver](https://jdbc.postgresql.org/)
+    - [PGJDBC-NG](https://impossibl.github.io/pgjdbc-ng/)
+    - [Skunk](https://tpolecat.github.io/skunk/)
+    - [postgresql-async](https://github.com/postgresql-async/postgresql-async)
+    - [quill-ndbc-postgres](https://getquill.io/#docs)
+
 ## v94
 
 * Adjust curl retry and connection timeout handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Main
 
-* Only provision Heroku Postgres if the app declares a dependency to one of the following postgres drivers:
+* Only provision Heroku Postgres if the app declares a dependency on one of the following postgres drivers:
     - [Official Postgres JDBC Driver](https://jdbc.postgresql.org/)
     - [PGJDBC-NG](https://impossibl.github.io/pgjdbc-ng/)
     - [Skunk](https://tpolecat.github.io/skunk/)

--- a/bin/compile
+++ b/bin/compile
@@ -161,6 +161,8 @@ fi
 # build app
 run_sbt "$javaVersion" "$SBT_USER_HOME_ABSOLUTE" "$SBT_BINDIR/$SBT_JAR" "$SBT_TASKS"
 
+write_sbt_dependency_classpath_log "$SBT_USER_HOME_ABSOLUTE" "$SBT_BINDIR/$SBT_JAR" "show dependencyClasspath"
+
 # repack cache
 mkdir -p $CACHE_DIR
 for DIR in $CACHED_DIRS; do

--- a/bin/release
+++ b/bin/release
@@ -8,10 +8,25 @@ BUILD_DIR=$1
 
 cat <<EOF
 ---
+
+EOF
+
+dependencies_file_path="${BUILD_DIR}/.heroku/sbt-dependency-classpath.log";
+
+if grep -q "com/impossibl/pgjdbc-ng" "${dependencies_file_path}" ||
+  grep -q "org/postgresql" "${dependencies_file_path}" ||
+  grep -q "skunk-core" "${dependencies_file_path}" ||
+  grep -q "postgresql-async" "${dependencies_file_path}" ||
+  grep -q "quill-ndbc-postgres" "${dependencies_file_path}"; then
+
+cat <<EOF
 addons:
   - heroku-postgresql
 
 EOF
+
+fi
+
 if [ ! -f $BUILD_DIR/Procfile ]; then
   if uses_universal_packaging $BUILD_DIR; then
     echo "default_process_types:"

--- a/bin/release
+++ b/bin/release
@@ -13,11 +13,13 @@ EOF
 
 dependencies_file_path="${BUILD_DIR}/.heroku/sbt-dependency-classpath.log";
 
-if grep -q "com/impossibl/pgjdbc-ng" "${dependencies_file_path}" ||
-  grep -q "org/postgresql" "${dependencies_file_path}" ||
-  grep -q "skunk-core" "${dependencies_file_path}" ||
-  grep -q "postgresql-async" "${dependencies_file_path}" ||
-  grep -q "quill-ndbc-postgres" "${dependencies_file_path}"; then
+if [[ -f "${dependencies_file_path}" ]] && (
+    grep -q "com/impossibl/pgjdbc-ng" "${dependencies_file_path}" ||
+    grep -q "org/postgresql" "${dependencies_file_path}" ||
+    grep -q "skunk-core" "${dependencies_file_path}" ||
+    grep -q "postgresql-async" "${dependencies_file_path}" ||
+    grep -q "quill-ndbc-postgres" "${dependencies_file_path}"
+  ); then
 
 cat <<EOF
 addons:

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -306,6 +306,14 @@ run_sbt() {
   fi
 }
 
+write_sbt_dependency_classpath_log() {
+  local home=$1
+  local launcher=$2
+
+  status "Collecting dependency information"
+  SBT_HOME="$home" sbt "show dependencyClasspath" | grep -o "Attributed\(.*\)" > .heroku/sbt-dependency-classpath.log
+}
+
 cache_copy() {
   rel_dir=$1
   from_dir=$2

--- a/opt/sbt-wrapper.sh
+++ b/opt/sbt-wrapper.sh
@@ -26,4 +26,4 @@ sbt-extras ${SBT_EXTRAS_OPTS} \
   -Dfile.encoding=UTF8 \
   -Dsbt.global.base=$sbtHome \
   $(([ -n "$HEROKU_TEST_RUN_ID" ] || [[ "$DYNO" != *run.* ]]) && echo "-Dsbt.log.noformat=true -batch") -no-colors \
-  $@
+  "$@"

--- a/test/release_test.sh
+++ b/test/release_test.sh
@@ -4,8 +4,39 @@
 
 testRelease()
 {
+  touch "${BUILD_DIR}/.heroku/sbt-dependency-classpath.log"
+
   expected_release_output=`cat <<EOF
 ---
+
+EOF`
+
+  release
+
+  assertCapturedSuccess
+  assertCapturedEquals "${expected_release_output}"
+}
+
+testReleaseWithPostgres()
+{
+  mkdir -p "${BUILD_DIR}/.heroku"
+  cat << EOF > "${BUILD_DIR}/.heroku/sbt-dependency-classpath.log"
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/scala-library/2.13.9/scala-library-2.13.9.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/twirl-api_2.13/1.5.1/twirl-api_2.13-1.5.1.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play-server_2.13/2.8.16/play-server_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play-logback_2.13/2.8.16/play-logback_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play-akka-http-server_2.13/2.8.16/play-akka-http-server_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/filters-helpers_2.13/2.8.16/filters-helpers_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play-guice_2.13/2.8.16/play-guice_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play-jdbc_2.13/2.8.16/play-jdbc_2.13-2.8.16.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/org/postgresql/postgresql/9.4-1206-jdbc42/postgresql-9.4-1206-jdbc42.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/org/scala-lang/modules/scala-xml_2.13/1.2.0/scala-xml_2.13-1.2.0.jar)
+Attributed(/tmp/scala_buildpack_build_dir/.sbt_home/.cache/coursier/v1/https/repo1.maven.org/maven2/com/typesafe/play/play_2.13/2.8.16/play_2.13-2.8.16.jar)
+EOF
+
+  expected_release_output=`cat <<EOF
+---
+
 addons:
   - heroku-postgresql
 
@@ -24,8 +55,6 @@ testPlay20Release()
 
   expected_release_output=`cat <<EOF
 ---
-addons:
-  - heroku-postgresql
 
 default_process_types:
   web: target/start -Dhttp.port=\\$PORT \\$JAVA_OPTS


### PR DESCRIPTION
Previously, the Scala buildpack always provisioned a Heroku Postgres addon. With this PR, it will only provision Heroku Postgres if the app declares a dependency to one of the following postgres drivers:
   - [Official Postgres JDBC Driver](https://jdbc.postgresql.org/)
   - [PGJDBC-NG](https://impossibl.github.io/pgjdbc-ng/)
   - [Skunk](https://tpolecat.github.io/skunk/)
   - [postgresql-async](https://github.com/postgresql-async/postgresql-async)
   - [quill-ndbc-postgres](https://getquill.io/#docs)
    
Closes GUS-W-11780968