### PR TITLE
Convert heroku/heroku-buildpack-scala to GitHub Actions

### DIFF
--- a/.github/workflows/default-ci-workflow.yml
+++ b/.github/workflows/default-ci-workflow.yml
@@ -1,0 +1,60 @@
+name: heroku/heroku-buildpack-scala/default-ci-workflow
+on:
+  push:
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  buildpack-testrunner:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: openjdk:8
+    env:
+      SHUNIT_HOME: xxxxxxx
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install required apt packages
+      run: |-
+        sudo apt-get update
+        sudo apt-get install file
+    - name: Download and unpack shunit 2.1.6
+      run: curl -sSf --fail --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+    - name: Clone heroku-buildpack-testrunner
+      run: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner
+    - name: Execute buildpack-testrunner
+      run: "/tmp/testrunner/bin/run ."
+  hatchet:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    env:
+      PARALLEL_SPLIT_TEST_PROCESSES: xxxxxxx
+      HATCHET_BUILDPACK_BASE: xxxxxxx
+      HATCHET_BUILDPACK_BRANCH: xxxxxxx
+      HATCHET_APP_LIMIT: xxxxxxx
+      HATCHET_EXPENSIVE_MODE: xxxxxxx
+      HATCHET_RUN_MULTI: xxxxxxx
+      DEFAULT_APP_STACK: xxxxxxx
+    strategy:
+      matrix:
+        heroku-stack:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      run: |-
+        if [[ $(command -v heroku) == "" ]]; then
+          curl https://cli-assets.heroku.com/install.sh | sh
+        else
+          echo "Heroku is already installed. No operation was performed."
+        fi
+    - name: Install Ruby dependencies
+      run: |-
+        gem install bundler
+        bundle install
+    - name: Hatchet CI setup
+      run: bundle exec hatchet ci:setup
+    - name: Execute rspec w/ parallel_split_test
+      run: bundle exec parallel_split_test test/spec/


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-scala) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/heroku-buildpack-scala/default-ci-workflow
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest