### PR TITLE
Add `DISABLE_DEPENDENCY_CLASSPATH_LOG` environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Main
 
+
+## v96
+
+* Add support for the `DISABLE_DEPENDENCY_CLASSPATH_LOG` environment variable to disable the dependency classpath log. 
+
 ## v95
 
 * Only provision Heroku Postgres if the app declares a dependency on one of the following postgres drivers:

--- a/bin/compile
+++ b/bin/compile
@@ -161,7 +161,9 @@ fi
 # build app
 run_sbt "$javaVersion" "$SBT_USER_HOME_ABSOLUTE" "$SBT_BINDIR/$SBT_JAR" "$SBT_TASKS"
 
-write_sbt_dependency_classpath_log "$SBT_USER_HOME_ABSOLUTE" "$SBT_BINDIR/$SBT_JAR" "show dependencyClasspath"
+if [ -z "${DISABLE_DEPENDENCY_CLASSPATH_LOG:-}" ]; then
+  write_sbt_dependency_classpath_log "$SBT_USER_HOME_ABSOLUTE" "$SBT_BINDIR/$SBT_JAR" "show dependencyClasspath"
+fi
 
 # repack cache
 mkdir -p $CACHE_DIR


### PR DESCRIPTION
This is a stop-gap measure that allows customers to disable the dependency classpath logging if it causes problems with their app. A more permanent solution will be implemented later.

Changelog updated for immediate release.

Related: GUS-W-11834343