### PR TITLE
Remove heroku-18 stack support

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,17 +2,21 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize, labeled]
+    types: [opened, reopened, labeled, unlabeled, synchronize]
+
+permissions:
+  contents: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
+  check-changelog:
+    runs-on: ubuntu-22.04
     if: |
-      !contains(github.event.pull_request.body, '[skip changelog]') &&
-      !contains(github.event.pull_request.body, '[changelog skip]') &&
-      !contains(github.event.pull_request.body, '[skip ci]') &&
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
+      !contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Check that CHANGELOG is touched
-        run: git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md
+        run: |
+          git fetch origin ${{ github.base_ref }} --depth 1 && \
+          git diff remotes/origin/${{ github.base_ref }} --name-only | grep CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-18", "heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22"]
     env:
       HATCHET_APP_LIMIT: 100
       HATCHET_RUN_MULTI: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Main
 
+* Remove heroku-18 support ([#226](https://github.com/heroku/heroku-buildpack-scala/pull/226))
 
 ## v96
 


### PR DESCRIPTION
Since the Heroku-18 stack has reached end-of-life, and as such builds using it are no longer supported by the Heroku build system:
https://devcenter.heroku.com/changelog-items/2583

This fixes the integration tests failing in CI for the Heroku-18 stack, due to the build system now (as expected) rejecting the jobs.

Any non-Heroku consumers of this buildpack that wish to continue using the Heroku-18 stack should pin to the previous version of this buildpack.

Ref: GUS-W-10446298