### PR TITLE
Fix deprecation warning, drop sbt 1.0.x support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-* Remove heroku-18 support ([#226](https://github.com/heroku/heroku-buildpack-scala/pull/226))
+* Remove heroku-18 support. ([#226](https://github.com/heroku/heroku-buildpack-scala/pull/226))
+* Fix deprecation warnings when using sbt `>= 1.5`. ([#232](https://github.com/heroku/heroku-buildpack-scala/pull/232))
+* Support for sbt `1.0.x` has been removed. ([#232](https://github.com/heroku/heroku-buildpack-scala/pull/232))
 
 ## [v96] - 2022-09-30
 

--- a/bin/compile
+++ b/bin/compile
@@ -88,7 +88,7 @@ fi
 
 if ! (has_supported_sbt_version ${BUILD_DIR} || has_supported_sbt_1_version ${BUILD_DIR}); then
   error "You have defined an unsupported sbt.version in project/build.properties
-You must use a version of sbt between 0.11.0 and 1.x"
+For sbt 0.x you must use a version >= 0.11, for sbt 1.x you must use a version >= 1.1"
 fi
 
 if has_old_preset_sbt_opts; then

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 SBT_0_VERSION_PATTERN='sbt\.version=\(0\.1[1-3]\.[0-9]*\(-[a-zA-Z0-9_]*\)*\)$'
-SBT_1_VERSION_PATTERN='sbt\.version=\(1\.[0-9]*\.[0-9]*\(-[a-zA-Z0-9_]*\)*\)$'
+SBT_1_VERSION_PATTERN='sbt\.version=\(1\.[1-9]*\.[0-9]*\(-[a-zA-Z0-9_]*\)*\)$'
 
 ## SBT 0.10 allows either *.sbt in the root dir, or project/*.scala or .sbt/*.scala
 detect_sbt() {

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-SBT_0_VERSION_PATTERN='sbt\.version=\(0\.1[1-3]\.[0-9]*\(-[a-zA-Z0-9_]*\)*\)$'
-SBT_1_VERSION_PATTERN='sbt\.version=\(1\.[1-9]*\.[0-9]*\(-[a-zA-Z0-9_]*\)*\)$'
+SBT_0_VERSION_PATTERN='sbt\.version=\(0\.1[1-3]\.[0-9]\+\(-[a-zA-Z0-9_]\+\)*\)$'
+SBT_1_VERSION_PATTERN='sbt\.version=\(1\.[1-9][0-9]*\.[0-9]\+\(-[a-zA-Z0-9_]\+\)*\)$'
 
 ## SBT 0.10 allows either *.sbt in the root dir, or project/*.scala or .sbt/*.scala
 detect_sbt() {

--- a/opt/HerokuBuildpackPlugin_sbt1.scala
+++ b/opt/HerokuBuildpackPlugin_sbt1.scala
@@ -1,10 +1,12 @@
 import sbt._
-import Keys._
+import sbt.Keys._
 
 object HerokuBuildpackPlugin extends AutoPlugin {
+  override def trigger = allRequirements
+
   override lazy val projectSettings = Seq(
-    sources in doc in Compile := List(),
-    publishArtifact in packageDoc := false,
-    publishArtifact in packageSrc := false
+    Compile / doc / sources := List(),
+    packageDoc / publishArtifact := false,
+    packageSrc / publishArtifact := false
   )
 }

--- a/test/common_test.sh
+++ b/test/common_test.sh
@@ -174,13 +174,13 @@ testGetSupportedSbt1Version()
 {
   mkdir -p ${BUILD_DIR}/project
   cat > ${BUILD_DIR}/project/build.properties <<EOF
-sbt.version=1.0.0-RC3
+sbt.version=1.1.0-RC3
 EOF
 
   capture get_supported_sbt_version ${BUILD_DIR} ${SBT_1_VERSION_PATTERN}
 
   assertCapturedSuccess
-  assertCapturedEquals "1.0.0-RC3"
+  assertCapturedEquals "1.1.0-RC3"
 }
 
 testGetUnsupportedSbtVersion()

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -256,7 +256,7 @@ testComplile_BuildPropertiesFileWithUnsupportedOldVersion()
   compile
 
   assertCapturedError "You have defined an unsupported sbt.version in project/build.properties"
-  assertCapturedError "You must use a version of sbt between 0.11.0 and 1.x"
+  assertCapturedError "For sbt 0.x you must use a version >= 0.11, for sbt 1.x you must use a version >= 1.1"
 }
 
 testComplile_BuildPropertiesFileWithRCVersion()

--- a/test/release_test.sh
+++ b/test/release_test.sh
@@ -4,6 +4,7 @@
 
 testRelease()
 {
+  mkdir -p "${BUILD_DIR}/.heroku"
   touch "${BUILD_DIR}/.heroku/sbt-dependency-classpath.log"
 
   expected_release_output=`cat <<EOF


### PR DESCRIPTION
As reported in #231, the sbt plugin injected by this buildpack causes deprecation warnings with sbt `>= 1.5`. 

The fix requires the plugin to use the slash syntax which is only supported in sbt since `1.1`. Since version `1.0` is EOL for some time now and a migration to `1.1` or later is trivial, this PR removes sbt `1.0` support instead of providing a special plugin for that version. Error messages have been adjusted accordingly.

Fixes #231.
Ref: GUS-W-14387696