### PR TITLE
Fix `is_play` for Play 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Fix Play Framework detection for Play >= `3.0.0`. ([#240](https://github.com/heroku/heroku-buildpack-scala/pull/240))
 
 ## [v97] - 2024-02-07
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -17,7 +17,20 @@ detect_sbt() {
 }
 
 is_play() {
-  _has_playConfig $1
+  local app_dir=$1
+
+  case "${IS_PLAY_APP}" in
+  "true")
+    return 0
+    ;;
+  "false")
+    return 1
+    ;;
+  *)
+    [[ -f "${app_dir}/${PLAY_CONF_FILE:-conf/application.conf}" ]] ||
+      grep -E --quiet --no-messages '^\s*addSbtPlugin\(\s*("org\.playframework"|"com\.typesafe\.play")\s*%\s*"sbt-plugin"' "${app_dir}/project/plugins.sbt"
+    ;;
+  esac
 }
 
 is_sbt_native_packager() {
@@ -48,22 +61,6 @@ _has_hiddenSbtDir() {
 _has_buildPropertiesFile() {
   local ctxDir=$1
   test -e $ctxDir/project/build.properties
-}
-
-_has_playConfig() {
-  local ctxDir=$1
-  test -e $ctxDir/conf/application.conf ||
-      test "$IS_PLAY_APP" = "true" ||
-      (test -n "$PLAY_CONF_FILE" &&
-          test -e "$PLAY_CONF_FILE" &&
-          test "$IS_PLAY_APP" != "false") ||
-      (# test for default Play 2.3 and 2.4 setup.
-          test -d $ctxDir/project &&
-          test -r $ctxDir/project/plugins.sbt &&
-          test -n "$(grep "addSbtPlugin(\"com.typesafe.play\" % \"sbt-plugin\"" $ctxDir/project/plugins.sbt | grep -v ".*//.*addSbtPlugin")" &&
-          test -r $ctxDir/build.sbt &&
-          test -n "$(grep "enablePlugins(Play" $ctxDir/build.sbt | grep -v ".*//.*enablePlugins(Play")" &&
-          test "$IS_PLAY_APP" != "false")
 }
 
 _has_playPluginsFile() {


### PR DESCRIPTION
In rare cases when a Play application does not have a configuration file at `conf/application.conf` and `$PLAY_CONF_FILE` isn't set to the alternative location, the buildpack tries to determine if the Play sbt plugin is added to the project. Since Play 3.0, the group id for this plugin has changed from `com.typesafe.play` to `org.playframework`, causing Play 3.0 projects to not be detected as Play in such cases.

This PR reworks the `is_play` function:
- Add support for the group id used in Play 3.0. 
- The regular expression was made less strict when it comes to whitespace.
- Removed checking for the plugin enable statement as it might cause false negatives in more complex build setups.
- Removed `_has_playConfig` indirection. It was only used by `is_play` and did much more than just checking for a Play configuration file.
- Simplified the implementation