### PR TITLE
Add metrics infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add metrics infrastructure and collection ([#259](https://github.com/heroku/heroku-buildpack-scala/pull/259))
 * Remove heroku-20 support ([#252](https://github.com/heroku/heroku-buildpack-scala/pull/252))
 
 ## [v98] - 2024-02-14

--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,7 @@ LIB_DIR=$BP_DIR/lib
 . $LIB_DIR/common.sh
 . $LIB_DIR/properties.sh
 . $LIB_DIR/failures.sh
+. $LIB_DIR/metrics.sh
 
 # parse args
 APP_BUILD_DIR=$(cd $1; pwd)
@@ -21,6 +22,9 @@ CACHE_DIR=$2
 ENV_DIR=$3
 
 source $LIB_DIR/buildpack-stdlib-v7.sh
+
+metrics::init "${CACHE_DIR}" "scala"
+metrics::setup
 
 if [ -z "${CNB_STACK_ID:-}" ]; then
   # Move app to a static build dir to keep paths the same between builds

--- a/bin/compile
+++ b/bin/compile
@@ -61,6 +61,15 @@ SBT_PROJECT=$(get_property "$SYSPROPFILE" "sbt.project")
 SBT_PRE_TASKS=$(get_property "$SYSPROPFILE" "sbt.pre-tasks" "$SBT_PRE_TASKS")
 SBT_CLEAN=$(get_property "$SYSPROPFILE" "sbt.clean" "${SBT_CLEAN:-false}")
 
+[ -n "$SBT_PRE_TASKS" ] && metrics::set_string "sbt_pre_tasks" "$SBT_PRE_TASKS"
+[ -n "$SBT_PROJECT" ] && metrics::set_string "sbt_project" "$SBT_PROJECT"
+[ -n "${SBT_TASKS:-}" ] && metrics::set_string "sbt_tasks" "$SBT_TASKS"
+[ -n "$KEEP_PLAY_FORK_RUN" ] && metrics::set_string "keep_play_fork_run" "$KEEP_PLAY_FORK_RUN"
+[ -n "$KEEP_SBT_CACHE" ] && metrics::set_string "keep_sbt_cache" "$KEEP_SBT_CACHE"
+[ -n "$KEEP_COURSIER_CACHE" ] && metrics::set_string "keep_coursier_cache" "$KEEP_COURSIER_CACHE"
+[ -n "$SBT_CLEAN" ] && metrics::set_string "sbt_clean" "$SBT_CLEAN"
+[ -n "${DISABLE_DEPENDENCY_CLASSPATH_LOG:-}" ] && metrics::set_string "disable_dependency_classpath_log" "${DISABLE_DEPENDENCY_CLASSPATH_LOG}"
+
 # Install the JDK
 install_jdk "$BUILD_DIR" "$CACHE_DIR"
 
@@ -151,6 +160,21 @@ rm -f $SBT_USER_HOME/plugins/HerokuPlugin.scala # remove the old ambiguously nam
 rm -f $SBT_USER_HOME/plugins/HerokuBuildpackPlugin_sbt1.scala # remove the old poorly named plugin
 rm -f $SBT_USER_HOME/plugins/HerokuBuildpackPlugin.scala # remove the old plugin
 cp -p $OPT_DIR/$HEROKU_PLUGIN $SBT_USER_HOME/plugins/HerokuBuildpackPlugin.scala
+
+# Collect metrics
+metrics::set_string "sbt_version" "${SBT_VERSION:-unknown}"
+
+if is_sbt_native_packager $BUILD_DIR; then
+  metrics::set_raw "uses_sbt_native_packager" "true"
+else
+  metrics::set_raw "uses_sbt_native_packager" "false"
+fi
+
+if is_play $BUILD_DIR; then
+  metrics::set_raw "is_play_app" "true"
+else
+  metrics::set_raw "is_play_app" "false"
+fi
 
 # Manually pre-clean because sbt-native-packager doesn't clobber this dir
 rm -rf $BUILD_DIR/target/universal/stage

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Produces a build report containing metadata about the build, that's consumed by the build system.
+# This script is run for both successful and failing builds, so it should not assume the build ran
+# to completion (e.g. OpenJDK may not even have been installed).
+#
+# Metadata must be emitted to stdout as valid YAML key-value pairs. Any fields that should always
+# be typed as a string must be explicitly quoted.
+#
+# Example valid stdout:
+#   openjdk_version: 'X.Y.Z'
+#   openjdk_install_duration: 1.234
+#
+# Failures in this script don't cause the overall build to fail (and won't appear in user
+# facing build logs) to avoid breaking builds unnecessarily / causing confusion. To debug
+# issues check the internal build system logs for `buildpack.report.failed` events, or
+# when developing run `make run` in this repo locally, which runs `bin/report` too.
+
+# BUILD_DIR="${1}"
+CACHE_DIR="${2}"
+# ENV_DIR="${3}"
+
+BUILDPACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
+# The build system doesn't source the `export` script before running this script, so we have to do
+# so manually (if it exists) so that buildpack java can be found (if the build succeeded).
+EXPORT_FILE="${BUILDPACK_DIR}/export"
+if [[ -f "${EXPORT_FILE}" ]]; then
+	# shellcheck source=/dev/null
+	source "${EXPORT_FILE}"
+fi
+
+source "${BUILDPACK_DIR}/lib/metrics.sh"
+
+metrics::init "${CACHE_DIR}" "scala"
+metrics::print_bin_report_yaml

--- a/lib/metrics.sh
+++ b/lib/metrics.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+BUILDPACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
+# Variables shared by this whole module
+METRICS_DATA_FILE=""
+PREVIOUS_METRICS_DATA_FILE=""
+
+# Initializes the environment required for metrics collection.
+# Must be called before you can use any other functions from this file!
+#
+# Usage:
+# ```
+# metrics::init "${CACHE_DIR}" "scala"
+# ```
+function metrics::init() {
+	local cache_dir="${1}"
+	local buildpack_name="${2}"
+
+	METRICS_DATA_FILE="${cache_dir}/metrics-data/${buildpack_name}"
+	PREVIOUS_METRICS_DATA_FILE="${cache_dir}/metrics-data/${buildpack_name}-prev"
+}
+
+# Initializes the metrics collection environment by setting up data files.
+#
+# WARNING: This function prunes existing metrics should there be any.
+#
+# Usage:
+# ```
+# metrics::init "${CACHE_DIR}" "scala"
+# metrics::setup
+# ```
+function metrics::setup() {
+	if [[ -f "${METRICS_DATA_FILE}" ]]; then
+		cp "${METRICS_DATA_FILE}" "${PREVIOUS_METRICS_DATA_FILE}"
+	fi
+
+	mkdir -p "$(dirname "${METRICS_DATA_FILE}")"
+	echo "{}" >"${METRICS_DATA_FILE}"
+}
+
+# Sets a metric value as raw JSON data.
+# The value parameter must be valid JSON value (number, boolean, string, etc.).
+#
+# NOTE: Strings must be wrapped in double quotes (use `metrics::set_string` for convenience).
+#
+# Usage:
+# ```
+# metrics::set_raw "build_duration" "42.5"
+# metrics::set_raw "success" "true"
+# metrics::set_raw "message" '"Hello World"'
+# ```
+function metrics::set_raw() {
+	local key="${1}"
+	local value="${2}"
+
+	local new_data_file_contents
+	new_data_file_contents=$(jq <"${METRICS_DATA_FILE}" --arg key "${key}" --argjson value "${value}" '. + { ($key): ($value) }')
+
+	echo "${new_data_file_contents}" >"${METRICS_DATA_FILE}"
+}
+
+# Sets a metric value as a string.
+# The value will be automatically wrapped in double quotes and escaped for JSON.
+#
+# Usage:
+# ```
+# metrics::set_string "buildpack_version" "1.2.3"
+# metrics::set_string "jvm_distribution" "Heroku"
+# ```
+function metrics::set_string() {
+	local key="${1}"
+	local value="${2}"
+
+	# This works because jq's `--arg` always results in a string value
+	metrics::set_raw "${key}" "$(jq -n --arg value "${value}" '$value')"
+}
+
+# Sets a metric for elapsed time between two timestamps.
+# If end timestamp is not provided, current time is used.
+# Time is calculated in seconds with millisecond precision.
+#
+# Usage:
+# ```
+# start_time=$(nowms)
+# # ... some operation ...
+# metrics::set_duration "compile_duration" "${start_time}"
+# ```
+function metrics::set_duration() {
+	local key="${1}"
+	local start="${2}"
+	local end="${3:-$(nowms)}"
+	local time
+	time="$(echo "${start}" "${end}" | awk '{ printf "%.3f", ($2 - $1)/1000 }')"
+	metrics::set_raw "${key}" "${time}"
+}
+
+# Prints all metrics data in YAML format suitable for `bin/report`.
+# Each metric key-value pair is output as a separate YAML line.
+#
+# Usage:
+# ```
+# metrics::print_bin_report_yaml
+# ```
+function metrics::print_bin_report_yaml() {
+	jq -r 'keys[] as $key | (.[$key] | tojson) as $value | "\($key): \($value)"' <"${METRICS_DATA_FILE}"
+}


### PR DESCRIPTION
Adds metrics collection to the Scala buildpack to track how users configure and use buildpack features. Follows the same patterns as the Gradle buildpack.

**What we track:**
- `sbt_version` - SBT version from `project/build.properties`
- `uses_sbt_native_packager` - Whether project uses sbt-native-packager
- `is_play_app` - Whether project is a Play app
- `sbt_pre_tasks`, `sbt_project`, `sbt_tasks` - User-defined SBT configuration
- `keep_play_fork_run`, `keep_sbt_cache`, `keep_coursier_cache` - Cache settings
- `sbt_clean` - Whether clean builds are enabled
- `disable_dependency_classpath_log` - Whether dependency logging is disabled
- Everything that the JVM common buildpack tracks

This helps us understand which features users actually use and how they configure the buildpack for the upcoming refactoring work.

[W-18988450](https://gus.lightning.force.com/a07EE00002Hil5vYAB)