### PR TITLE
Update slug size expectations in hatchet tests

### DIFF
--- a/test/spec/cache_spec.rb
+++ b/test/spec/cache_spec.rb
@@ -50,7 +50,7 @@ describe 'Scala buildpack' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 114M
+          remote:        Done: 114.2M
         OUTPUT
 
         app.commit!
@@ -91,7 +91,7 @@ describe 'Scala buildpack' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 114M
+          remote:        Done: 114.2M
         OUTPUT
       end
     end
@@ -1104,7 +1104,7 @@ describe 'Scala buildpack' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 99.8M
+          remote:        Done: 99.9M
         OUTPUT
       end
     end

--- a/test/spec/sbt_multi_project_spec.rb
+++ b/test/spec/sbt_multi_project_spec.rb
@@ -43,7 +43,7 @@ describe 'Sbt multi-project builds' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 106.6M
+          remote:        Done: 106.7M
         OUTPUT
 
         response = http_get(app)
@@ -94,7 +94,7 @@ describe 'Sbt multi-project builds' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 106.6M
+          remote:        Done: 106.7M
         OUTPUT
 
         response = http_get(app)

--- a/test/spec/sbt_spec.rb
+++ b/test/spec/sbt_spec.rb
@@ -56,7 +56,7 @@ describe 'Sbt' do
           remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
-          remote:        Done: 106.5M
+          remote:        Done: 106.6M
         OUTPUT
       end
     end


### PR DESCRIPTION
The expected slug sizes in the hatchet tests drifted from the actual values produced by recent builds, causing failures across all stacks. This updates the expectations to match.