### PR TITLE
Improve reliability of the sbt launcher SHA-1 checksum download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `sbt` `2.x` support. ([#331](https://github.com/heroku/heroku-buildpack-scala/pull/331))
 * Fix the `sbt` launcher download error reporting to actually trigger on download failures. ([#332](https://github.com/heroku/heroku-buildpack-scala/pull/332))
+* Improve reliability of the sbt launcher SHA-1 checksum download. ([#329](https://github.com/heroku/heroku-buildpack-scala/pull/329))
 
 ## [v106] - 2026-02-24
 

--- a/lib/sbt.sh
+++ b/lib/sbt.sh
@@ -99,9 +99,32 @@ function sbt::download_sbt_launcher_jar() {
 	local sha1_path
 	sha1_path=$(mktemp)
 
-	if ! curl --silent --show-error --location "${sbt_launcher_jar_url}.sha1" >"${sha1_path}" 2>/dev/null; then
+	local sha1_http_status_code sha1_curl_exit_code=0
+	sha1_http_status_code=$(curl \
+		--retry 3 \
+		--retry-connrefused \
+		--connect-timeout 5 \
+		--silent \
+		--show-error \
+		--max-time 60 \
+		--location \
+		--write-out "%{http_code}" \
+		--output "${sha1_path}" \
+		"${sbt_launcher_jar_url}.sha1") || sha1_curl_exit_code=$?
+
+	if [[ "${sha1_curl_exit_code}" -ne 0 || "${sha1_http_status_code}" != "200" ]]; then
 		output::error <<-EOF
 			Error: Unable to download SHA-1 checksum for sbt launcher.
+
+			An error occurred while downloading the SHA-1 checksum from:
+			${sbt_launcher_jar_url}.sha1
+
+			In some cases, this happens due to a temporary issue with
+			the network connection or server.
+
+			Try building again to see if the error resolves itself.
+
+			HTTP status code: ${sha1_http_status_code}, curl exit code: ${sha1_curl_exit_code}
 		EOF
 
 		metrics::set_string "failure_reason" "install_sbt::checksum_unavailable"


### PR DESCRIPTION
The SHA-1 checksum download for the `sbt` launcher used a bare `curl` invocation without retries, timeouts, or HTTP status code checks. This makes it match the established best practices already used for the `sbt` launcher jar download in the same function: `--retry 3`, `--retry-connrefused`, `--connect-timeout 5`, `--max-time 60`, and an explicit HTTP status code check. The error message also now includes the failing URL, HTTP status, and curl exit code.

W-22927377