### PR TITLE
Fix sbt launcher download error reporting under set -e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add `sbt` `2.x` support. ([#331](https://github.com/heroku/heroku-buildpack-scala/pull/331))
 * Fix the `sbt` launcher download error reporting to actually trigger on download failures. ([#332](https://github.com/heroku/heroku-buildpack-scala/pull/332))
+* Improve reliability of the sbt launcher SHA-1 checksum download. ([#329](https://github.com/heroku/heroku-buildpack-scala/pull/329))
 
 ## [v106] - 2026-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Add `sbt` `2.x` support. ([#331](https://github.com/heroku/heroku-buildpack-scala/pull/331))
+* Fix the `sbt` launcher download error reporting to actually trigger on download failures. ([#332](https://github.com/heroku/heroku-buildpack-scala/pull/332))
 
 ## [v106] - 2026-02-24
 

--- a/lib/sbt.sh
+++ b/lib/sbt.sh
@@ -41,7 +41,7 @@ function sbt::download_sbt_launcher_jar() {
 		sbt_launcher_jar_url="https://repo.maven.apache.org/maven2/org/scala-sbt/sbt-launch/${sbt_version}/sbt-launch-${sbt_version}.jar"
 	fi
 
-	local http_status_code
+	local http_status_code curl_exit_code=0
 	http_status_code=$(curl \
 		--retry 3 \
 		--retry-connrefused \
@@ -52,9 +52,7 @@ function sbt::download_sbt_launcher_jar() {
 		--location \
 		--write-out "%{http_code}" \
 		--output "${destination_path}" \
-		"${sbt_launcher_jar_url}")
-
-	local curl_exit_code=$?
+		"${sbt_launcher_jar_url}") || curl_exit_code=$?
 
 	if [[ "${http_status_code}" == "404" ]]; then
 		output::error <<-EOF

--- a/lib/sbt.sh
+++ b/lib/sbt.sh
@@ -99,9 +99,32 @@ function sbt::download_sbt_launcher_jar() {
 	local sha1_path
 	sha1_path=$(mktemp)
 
-	if ! curl --silent --show-error --location "${sbt_launcher_jar_url}.sha1" >"${sha1_path}" 2>/dev/null; then
+	local sha1_http_status_code sha1_curl_exit_code=0
+	sha1_http_status_code=$(curl \
+		--retry 3 \
+		--retry-connrefused \
+		--connect-timeout 5 \
+		--silent \
+		--show-error \
+		--max-time 60 \
+		--location \
+		--write-out "%{http_code}" \
+		--output "${sha1_path}" \
+		"${sbt_launcher_jar_url}.sha1") || sha1_curl_exit_code=$?
+
+	if [[ "${sha1_curl_exit_code}" -ne 0 || "${sha1_http_status_code}" != "200" ]]; then
 		output::error <<-EOF
 			Error: Unable to download SHA-1 checksum for sbt launcher.
+
+			An error occurred while downloading the SHA-1 checksum from:
+			${sbt_launcher_jar_url}.sha1
+
+			In some cases, this happens due to a temporary issue with
+			the network connection or server.
+
+			Try building again to see if the error resolves itself.
+
+			HTTP status code: ${sha1_http_status_code}, curl exit code: ${sha1_curl_exit_code}
 		EOF
 
 		metrics::set_string "failure_reason" "install_sbt::checksum_unavailable"


### PR DESCRIPTION
The error-handling block after the `curl` invocation that downloads the `sbt` launcher jar was never reached on failure. With `set -e` enabled (as it is for this script), a `curl` failure inside `$(...)` aborts the script immediately, before the `local curl_exit_code=$?` capture and the `http_status_code` / `curl_exit_code` checks below it run. The script exits with curl's status and no diagnostic output is printed.

Guarding the command substitution with `|| curl_exit_code=$?` lets failures fall through to the existing error reporting.

Spotted by @edmorley in [#329](https://github.com/heroku/heroku-buildpack-scala/pull/329#discussion_r3388955872), which has the same flaw in the SHA-1 checksum download added there. That PR will be rebased on top of this fix.

W-22927377