### PR TITLE
Fix default web process auto-detection for sbt 2.x with sbt-native-packager

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -32,9 +32,15 @@ fi
 if [[ ! -f "${BUILD_DIR}/Procfile" ]]; then
 	# Use sbt-native-packager executable if exactly one is found.
 	# https://www.scala-sbt.org/sbt-native-packager/archetypes/java_app/index.html
-	# Search for executables in both single-project (target/universal/stage/bin) and
-	# multi-project (*/target/universal/stage/bin) locations.
-	mapfile -t -d '' sbt_native_packager_executables < <(find "${BUILD_DIR}" -path "*/target/universal/stage/bin/*" -type f -executable -print0 2>/dev/null)
+	# The two patterns match the sbt 1.x and sbt 2.x target layouts respectively. Multi-project
+	# builds are handled by both: sbt 1.x nests subprojects under their own target directory,
+	# while sbt 2.x places all subproject artifacts under the root target/out tree.
+	mapfile -t -d '' sbt_native_packager_executables < <(find "${BUILD_DIR}" \
+		\( \
+		-path "*/target/universal/stage/bin/*" \
+		-o -path "*/target/out/*/universal/stage/bin/*" \
+		\) \
+		-type f -executable -print0 2>/dev/null)
 	if [[ "${#sbt_native_packager_executables[@]}" -eq 1 ]]; then
 		# Include -Dhttp.port=$PORT since many sbt-native-packager apps use Play Framework.
 		# Apps that don't use the http.port system property will not be negatively affected by setting it.

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/.gitignore
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/.gitignore
@@ -1,0 +1,3 @@
+target/
+.bsp/
+.idea/

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/build.sbt
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/build.sbt
@@ -1,0 +1,15 @@
+lazy val root = (project in file("."))
+  .aggregate(subproject)
+  .settings(
+    name := "sbt-2.0.1-minimal-multi-project-with-native-packager-root"
+  )
+
+lazy val subproject = (project in file("subproject"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "sbt-2.0.1-minimal-multi-project-with-native-packager-subproject",
+    scalaVersion := "2.13.17",
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio-http" % "3.5.1"
+    )
+  )

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/project/build.properties
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=2.0.1

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/project/plugins.sbt
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.4")

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/subproject/src/main/scala/com/heroku/App.scala
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/subproject/src/main/scala/com/heroku/App.scala
@@ -1,0 +1,15 @@
+package com.heroku
+
+import zio._
+import zio.http._
+
+object App extends ZIOAppDefault {
+  private val routes = Routes(
+    Method.GET / Root -> handler(Response.text("Hello from Scala multi-project!"))
+  )
+
+  def run = for {
+    port <- System.env("PORT").map(_.flatMap(_.toIntOption).getOrElse(8080))
+    _ <- Server.serve(routes).provide(Server.defaultWithPort(port))
+  } yield ()
+}

--- a/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/system.properties
+++ b/test/spec/fixtures/repos/sbt-2.0.1-minimal-multi-project-with-native-packager/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=21

--- a/test/spec/sbt_multi_project_spec.rb
+++ b/test/spec/sbt_multi_project_spec.rb
@@ -52,6 +52,19 @@ describe 'Sbt multi-project builds' do
     end
   end
 
+  it 'builds an sbt 2.x multi-project app and serves traffic via the auto-detected web process' do
+    new_default_hatchet_runner('sbt-2.0.1-minimal-multi-project-with-native-packager').tap do |app|
+      app.before_deploy do
+        app.set_config('SBT_PROJECT' => 'subproject')
+      end
+
+      app.deploy do
+        response = http_get(app)
+        expect(response).to eq('Hello from Scala multi-project!')
+      end
+    end
+  end
+
   it 'applies project prefix to custom tasks when SBT_PROJECT and SBT_TASKS are both set' do
     new_default_hatchet_runner('sbt-1.11.7-minimal-multi-project-with-native-packager').tap do |app|
       app.before_deploy do

--- a/test/spec/sbt_spec.rb
+++ b/test/spec/sbt_spec.rb
@@ -3,6 +3,15 @@
 require_relative 'spec_helper'
 
 describe 'Sbt' do
+  it 'serves traffic via the auto-detected web process' do
+    new_default_hatchet_runner('sbt-1.11.7-minimal-with-native-packager').tap do |app|
+      app.deploy do
+        response = http_get(app)
+        expect(response).to eq('Hello from Scala!')
+      end
+    end
+  end
+
   it 'runs sbt-clean' do
     new_default_hatchet_runner('sbt-1.11.7-minimal-with-native-packager').tap do |app|
       app.before_deploy do

--- a/test/spec/sbt_version_spec.rb
+++ b/test/spec/sbt_version_spec.rb
@@ -179,7 +179,8 @@ describe 'Sbt version warnings' do
           remote: -----> Copying sbt and dependencies into slug for runtime use
           remote: -----> Dropping compilation artifacts from the slug
           remote: -----> Discovering process types
-          remote:        Procfile declares types -> (none)
+          remote:        Procfile declares types     -> (none)
+          remote:        Default types for buildpack -> web
 
           remote: -----> Compressing...
           remote:        Done: 106.8M

--- a/test/spec/sbt_version_spec.rb
+++ b/test/spec/sbt_version_spec.rb
@@ -185,6 +185,9 @@ describe 'Sbt version warnings' do
           remote: -----> Compressing...
           remote:        Done: 106.8M
         OUTPUT
+
+        response = http_get(app)
+        expect(response).to eq('Hello from Scala!')
       end
     end
   end


### PR DESCRIPTION
`sbt` `2.x` changed the layout of the `target` directory, causing web process auto-detection to not detect `sbt-native-packager` artifacts.

The `find` invocation now uses two `-path` predicates joined with `-o` so the `sbt` `1.x` and `sbt` `2.x` layouts both work.