### PR TITLE
Update Ruby to 4.0 and refresh dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Install shfmt
         run: sudo apt-get install shfmt
       - run: make lint-scripts
@@ -54,7 +54,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Hatchet setup
         run: bundle exec hatchet ci:setup
       - name: Run Hatchet integration tests

--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "3.4"
+          ruby-version: "4.0"
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,14 @@
 
 source 'https://rubygems.org'
 
-gem 'heroku_hatchet'
-gem 'java-properties'
-gem 'parallel_split_test'
-gem 'rspec-expectations'
-gem 'rspec-retry'
-gem 'rubocop'
-gem 'rubocop-rspec'
+ruby '>= 3.3', '< 4.1'
+
+group :test, :development do
+  gem 'heroku_hatchet'
+  gem 'java-properties'
+  gem 'parallel_split_test'
+  gem 'rspec-expectations'
+  gem 'rspec-retry'
+  gem 'rubocop'
+  gem 'rubocop-rspec'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,13 @@ GEM
     ast (2.4.3)
     base64 (0.3.0)
     diff-lcs (1.6.2)
-    erubis (2.7.0)
-    excon (1.5.0)
+    excon (1.7.1)
       logger
-    heroics (0.1.3)
+    heroics (0.1.4)
       base64
-      erubis (~> 2.0)
       excon
+      json
       moneta
-      multi_json (>= 1.9.2)
       webrick
     heroku_hatchet (8.0.6)
       excon (< 2)
@@ -21,20 +19,19 @@ GEM
       thor (~> 1)
       threaded (~> 0)
     java-properties (0.3.0)
-    json (2.21.2)
+    json (3.0.2)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
     logger (1.7.0)
     moneta (1.0.0)
-    multi_json (1.21.1)
-    parallel (2.1.0)
+    parallel (2.2.0)
     parallel_split_test (0.10.0)
       parallel (>= 0.5.13)
       rspec-core (>= 3.9.0)
     parser (3.3.12.0)
       ast (~> 2.4.1)
       racc
-    platform-api (3.8.0)
+    platform-api (3.9.1)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
@@ -44,14 +41,14 @@ GEM
     rate_throttle_client (0.1.2)
     regexp_parser (2.12.0)
     rrrretry (1.0.0)
-    rspec-core (3.13.0)
+    rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-support (3.13.4)
+    rspec-support (3.13.7)
     rubocop (1.90.0)
       json (>= 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -71,15 +68,17 @@ GEM
       regexp_parser (>= 2.0)
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
-    thor (1.4.0)
+    thor (1.5.0)
     threaded (0.0.4)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   heroku_hatchet
@@ -90,5 +89,46 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
 
+CHECKSUMS
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  bundler (4.0.20) sha256=7978a8ac648767f5e635bc522445b79e80a52b907a39a36c2d8085ed6bc762ae
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  excon (1.7.1) sha256=dd2d870eece1b5ce4e4f9efd938e67a69ccd8c003c3825b638b937e1082eaac2
+  heroics (0.1.4) sha256=8d843fb0a2cb55f36d1754d1f684e2e2685573ab90ff23dad122d30c66b7021c
+  heroku_hatchet (8.0.6) sha256=886a7d7d686859db9fac19df1194a35c5349285956ca4d134054c5c376accea3
+  java-properties (0.3.0) sha256=0a9fdda90c25ba9ba4de0e242d954a5688629652b592aab66ed54e2b16b93093
+  json (3.0.2) sha256=8e6d7e7b11384c21230430cef90b71f14849a34a1f4452796670f7c981bd19df
+  language_server-protocol (3.17.0.6) sha256=5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  moneta (1.0.0) sha256=2224e5a68156e8eceb525fb0582c8c4e0f29f67cae86507cdcfb406abbb1fc5d
+  parallel (2.2.0) sha256=e1059c5fd7b649558a0aec38a769f06a42942bdb40503d005a59c352fe011cd8
+  parallel_split_test (0.10.0) sha256=4abd6bedc6a1b169ecb93a1bf982fa7fbd437b66c360594d56d107c25f53b05f
+  parser (3.3.12.0) sha256=21a6d7f755d5a24dfbdc6e6b772e4e879a52e7631a88bc5a3a134606052c9828
+  platform-api (3.9.1) sha256=771f8a2dd19136e9f2715c5fad6b5b2c628398216091f3e8bd5fe86b5f094a75
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rate_throttle_client (0.1.2) sha256=f9de968b892fea9272154f6182b4f5cfb74292585e66763fb8a8510181ec83ee
+  regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
+  rrrretry (1.0.0) sha256=3c60784501701a49d8ad499af7e76dbddf9a8be916beffe885bd0f443ad1c749
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  rubocop (1.90.0) sha256=9eb4c065b5c5154e4ef554c547972f3905a9eb6b53e657e580b6796b54bf8242
+  rubocop-ast (1.50.0) sha256=b9ca88300da0803ee222ad20cdb30494c0a784eed06fdc35d254b06d662788db
+  rubocop-rspec (3.10.2) sha256=0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  thor (1.5.0) sha256=e3a9e55fe857e44859ce104a84675ab6e8cd59c650a49106a05f55f136425e73
+  threaded (0.0.4) sha256=8f32c11d29f7c7237aabeb36d286c15ac495137ce06ace3357de743aafd4f0e3
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+
+RUBY VERSION
+  ruby 4.0.6
+
 BUNDLED WITH
-   2.6.9
+  4.0.20

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
   config.default_retry_count = 2 if ENV['CI']
 end
 
-def new_default_hatchet_runner(*args, **kwargs)
+def new_default_hatchet_runner(*, **kwargs)
   kwargs[:stack] ||= ENV.fetch('DEFAULT_APP_STACK', nil)
   kwargs[:config] ||= {}
 
@@ -27,7 +27,7 @@ def new_default_hatchet_runner(*args, **kwargs)
     end
   end
 
-  Hatchet::Runner.new(*args, **kwargs)
+  Hatchet::Runner.new(*, **kwargs)
 end
 
 def write_to_procfile(content)


### PR DESCRIPTION
Ports the improvements made to the classic Node.js buildpack while fixing its CI (heroku/heroku-buildpack-nodejs#1790) to this repo.

- Add a `ruby ">= 3.3", "< 4.1"` constraint to the `Gemfile` and move
  the gems into a `test`, `development` group.
- Regenerate `Gemfile.lock`: update bundler to 4.0.20, refresh all
  dependencies, add checksums, and add the `arm64-darwin-24` and
  `x86_64-linux` platforms.
- Update the Ruby version to 4.0 in the GitHub Actions workflows.
- Apply `rubocop` autocorrections surfaced by the newer RuboCop.

GUS-W-24141750.